### PR TITLE
fix: remove ghost form steps in the apply now form

### DIFF
--- a/src/pages/ApplyNow/sections/FormSteps.jsx
+++ b/src/pages/ApplyNow/sections/FormSteps.jsx
@@ -157,7 +157,7 @@ function FormSteps() {
   function renderStep(step) {
 
     return (
-      <div key={step.step} className={`${step.step == currentStep ? "flex flex-col" : "h-0 opacity-0 pointer-events-none"} w-full p-2 gap-2`}>
+      <div key={step.step} className={`w-full p-2 gap-2 ${step.step == currentStep ? "flex flex-col" : "opacity-0 pointer-events-none absolute"}`}>
         {step.inputs.map((input, index) => {
           let lgLayout = ""; 
           if (input instanceof Array) {return (


### PR DESCRIPTION
In this PR, the following changes were made: 

- hidden form steps still have padding and height, remove form doc flow for better look